### PR TITLE
doxygen: Document all namespaces

### DIFF
--- a/lib/ome/common/module.h
+++ b/lib/ome/common/module.h
@@ -49,6 +49,9 @@
 # include <ome/common/config.h>
 # include <ome/common/filesystem.h>
 
+/**
+ * Open Microscopy Environment C++.
+ */
 namespace ome
 {
   namespace common

--- a/lib/ome/common/units/types.h
+++ b/lib/ome/common/units/types.h
@@ -56,6 +56,9 @@ namespace ome
 {
   namespace common
   {
+    /**
+     * Units of measurement.
+     */
     namespace units
     {
 


### PR DESCRIPTION
Add missing namespace descriptions; this adds the namespaces to the API docs, which makes them browseable.

Testing: See the API reference namespace list.
