### PR TITLE
Basic C++11 features

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,8 +1,3 @@
-# Try to put the compiler into the most recent standard mode.  This
-# will generally have the most features, and will remove the need for
-# Boost fallbacks if native implementations are available.
-option(cxxstd-autodetect "Enable C++14 features if possible, otherwise fall back to C++11, C++03 or C++98" OFF)
-
 # These are annoyingly verbose, produce false positives or don't work
 # nicely with all supported compiler versions, so are disabled unless
 # explicitly enabled.

--- a/lib/ome/common/base64.h
+++ b/lib/ome/common/base64.h
@@ -40,11 +40,10 @@
 #define OME_COMMON_BASE64_H
 
 #include <cctype>
+#include <cstdint>
 #include <iterator>
 #include <stdexcept>
 #include <string>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/lib/ome/common/boolean.h
+++ b/lib/ome/common/boolean.h
@@ -39,6 +39,7 @@
 #ifndef OME_COMMON_BOOLEAN_H
 #define OME_COMMON_BOOLEAN_H
 
+#include <cstdint>
 #include <istream>
 #include <limits>
 #include <ostream>

--- a/lib/ome/common/boolean.h
+++ b/lib/ome/common/boolean.h
@@ -44,8 +44,6 @@
 #include <limits>
 #include <ostream>
 
-#include <ome/compat/cstdint.h>
-
 #ifdef _MSC_VER
 #pragma push_macro("min")
 #undef min

--- a/lib/ome/common/units/electric-potential.h
+++ b/lib/ome/common/units/electric-potential.h
@@ -69,49 +69,49 @@ namespace ome
       typedef quantity<si::electric_potential> electric_potential_quantity;
 
       /// Unit definition for yoctovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-24> > >::type yoctovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-24>>>::type yoctovolt_unit;
       /// Unit definition for zeptovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-21> > >::type zeptovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-21>>>::type zeptovolt_unit;
       /// Unit definition for attovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-18> > >::type attovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-18>>>::type attovolt_unit;
       /// Unit definition for femtovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-15> > >::type femtovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-15>>>::type femtovolt_unit;
       /// Unit definition for picovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-12> > >::type picovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<-12>>>::type picovolt_unit;
       /// Unit definition for nanovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -9> > >::type nanovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -9>>>::type nanovolt_unit;
       /// Unit definition for microvolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -6> > >::type microvolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -6>>>::type microvolt_unit;
       /// Unit definition for millivolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -3> > >::type millivolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -3>>>::type millivolt_unit;
       /// Unit definition for centivolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -2> > >::type centivolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -2>>>::type centivolt_unit;
       /// Unit definition for decivolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -1> > >::type decivolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< -1>>>::type decivolt_unit;
       /// Unit definition for volt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  0> > >::type volt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  0>>>::type volt_unit;
       /// Unit definition for dekavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  1> > >::type dekavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  1>>>::type dekavolt_unit;
       /// Unit definition for decavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  1> > >::type decavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  1>>>::type decavolt_unit;
       /// Unit definition for hectovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  2> > >::type hectovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  2>>>::type hectovolt_unit;
       /// Unit definition for kilovolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  3> > >::type kilovolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  3>>>::type kilovolt_unit;
       /// Unit definition for megavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  6> > >::type megavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  6>>>::type megavolt_unit;
       /// Unit definition for gigavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  9> > >::type gigavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational<  9>>>::type gigavolt_unit;
       /// Unit definition for teravolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 12> > >::type teravolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 12>>>::type teravolt_unit;
       /// Unit definition for petavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 15> > >::type petavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 15>>>::type petavolt_unit;
       /// Unit definition for exavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 18> > >::type exavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 18>>>::type exavolt_unit;
       /// Unit definition for zettavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 21> > >::type zettavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 21>>>::type zettavolt_unit;
       /// Unit definition for yottavolt electric potential.
-      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 24> > >::type yottavolt_unit;
+      typedef make_scaled_unit<si::electric_potential,scale<10,static_rational< 24>>>::type yottavolt_unit;
 
       /// Numeric constant for yoctovolt.
       BOOST_UNITS_STATIC_CONSTANT(yoctovolt, yoctovolt_unit);

--- a/lib/ome/common/units/frequency.h
+++ b/lib/ome/common/units/frequency.h
@@ -69,49 +69,49 @@ namespace ome
       typedef quantity<si::frequency> frequency_quantity;
 
       /// Unit definition for yoctohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-24> > >::type yoctohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-24>>>::type yoctohertz_unit;
       /// Unit definition for zeptohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-21> > >::type zeptohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-21>>>::type zeptohertz_unit;
       /// Unit definition for attohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-18> > >::type attohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-18>>>::type attohertz_unit;
       /// Unit definition for femtohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-15> > >::type femtohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-15>>>::type femtohertz_unit;
       /// Unit definition for picohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-12> > >::type picohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<-12>>>::type picohertz_unit;
       /// Unit definition for nanohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -9> > >::type nanohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -9>>>::type nanohertz_unit;
       /// Unit definition for microhertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -6> > >::type microhertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -6>>>::type microhertz_unit;
       /// Unit definition for millihertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -3> > >::type millihertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -3>>>::type millihertz_unit;
       /// Unit definition for centihertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -2> > >::type centihertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -2>>>::type centihertz_unit;
       /// Unit definition for decihertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -1> > >::type decihertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< -1>>>::type decihertz_unit;
       /// Unit definition for hertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  0> > >::type hertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  0>>>::type hertz_unit;
       /// Unit definition for dekahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  1> > >::type dekahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  1>>>::type dekahertz_unit;
       /// Unit definition for decahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  1> > >::type decahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  1>>>::type decahertz_unit;
       /// Unit definition for hectohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  2> > >::type hectohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  2>>>::type hectohertz_unit;
       /// Unit definition for kilohertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  3> > >::type kilohertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  3>>>::type kilohertz_unit;
       /// Unit definition for megahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  6> > >::type megahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  6>>>::type megahertz_unit;
       /// Unit definition for gigahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  9> > >::type gigahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational<  9>>>::type gigahertz_unit;
       /// Unit definition for terahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 12> > >::type terahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 12>>>::type terahertz_unit;
       /// Unit definition for petahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 15> > >::type petahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 15>>>::type petahertz_unit;
       /// Unit definition for exahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 18> > >::type exahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 18>>>::type exahertz_unit;
       /// Unit definition for zettahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 21> > >::type zettahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 21>>>::type zettahertz_unit;
       /// Unit definition for yottahertz frequency.
-      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 24> > >::type yottahertz_unit;
+      typedef make_scaled_unit<si::frequency,scale<10,static_rational< 24>>>::type yottahertz_unit;
 
       /// Numeric constant for yoctohertz.
       BOOST_UNITS_STATIC_CONSTANT(yoctohertz, yoctohertz_unit);

--- a/lib/ome/common/units/length.h
+++ b/lib/ome/common/units/length.h
@@ -79,49 +79,49 @@ namespace ome
       typedef quantity<si::length> length_quantity;
 
       /// Unit definition for yoctometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<-24> > >::type yoctometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<-24>>>::type yoctometre_unit;
       /// Unit definition for zeptometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<-21> > >::type zeptometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<-21>>>::type zeptometre_unit;
       /// Unit definition for attometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<-18> > >::type attometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<-18>>>::type attometre_unit;
       /// Unit definition for femtometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<-15> > >::type femtometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<-15>>>::type femtometre_unit;
       /// Unit definition for picometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<-12> > >::type picometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<-12>>>::type picometre_unit;
       /// Unit definition for nanometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< -9> > >::type nanometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< -9>>>::type nanometre_unit;
       /// Unit definition for micrometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< -6> > >::type micrometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< -6>>>::type micrometre_unit;
       /// Unit definition for millimetre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< -3> > >::type millimetre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< -3>>>::type millimetre_unit;
       /// Unit definition for centimetre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< -2> > >::type centimetre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< -2>>>::type centimetre_unit;
       /// Unit definition for decimetre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< -1> > >::type decimetre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< -1>>>::type decimetre_unit;
       /// Unit definition for metre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  0> > >::type metre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  0>>>::type metre_unit;
       /// Unit definition for dekametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  1> > >::type dekametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  1>>>::type dekametre_unit;
       /// Unit definition for decametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  1> > >::type decametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  1>>>::type decametre_unit;
       /// Unit definition for hectometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  2> > >::type hectometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  2>>>::type hectometre_unit;
       /// Unit definition for kilometre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  3> > >::type kilometre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  3>>>::type kilometre_unit;
       /// Unit definition for megametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  6> > >::type megametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  6>>>::type megametre_unit;
       /// Unit definition for gigametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational<  9> > >::type gigametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational<  9>>>::type gigametre_unit;
       /// Unit definition for terametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< 12> > >::type terametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< 12>>>::type terametre_unit;
       /// Unit definition for petametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< 15> > >::type petametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< 15>>>::type petametre_unit;
       /// Unit definition for exametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< 18> > >::type exametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< 18>>>::type exametre_unit;
       /// Unit definition for zettametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< 21> > >::type zettametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< 21>>>::type zettametre_unit;
       /// Unit definition for yottametre length.
-      typedef make_scaled_unit<si::length,scale<10,static_rational< 24> > >::type yottametre_unit;
+      typedef make_scaled_unit<si::length,scale<10,static_rational< 24>>>::type yottametre_unit;
 
       /// Unit definition for yoctometer length.
       typedef yoctometre_unit yoctometer_unit;
@@ -457,7 +457,7 @@ namespace ome
       typedef quantity<thou_unit> thou_quantity;
 
       /// Base unit definition for line length (defined as 1/12 inch, used in botany).
-      typedef scaled_base_unit<boost::units::imperial::inch_base_unit, scale<12, static_rational<-1> > > line_base_unit;
+      typedef scaled_base_unit<boost::units::imperial::inch_base_unit, scale<12, static_rational<-1>>> line_base_unit;
       /// Unit definition for line length (defined as 1/12 inch, used in botany).
       typedef line_base_unit::unit_type line_unit;
       /// Numeric constant for line.
@@ -531,7 +531,7 @@ namespace ome
       typedef quantity<parsec_unit> parsec_quantity;
 
       /// Base unit definition for point length.
-      typedef scaled_base_unit<boost::units::imperial::inch_base_unit, scale<72, static_rational<-1> > > point_base_unit;
+      typedef scaled_base_unit<boost::units::imperial::inch_base_unit, scale<72, static_rational<-1>>> point_base_unit;
       /// Unit definition for point length.
       typedef point_base_unit::unit_type point_unit;
       /// Numeric constant for point.

--- a/lib/ome/common/units/power.h
+++ b/lib/ome/common/units/power.h
@@ -69,49 +69,49 @@ namespace ome
       typedef quantity<si::power> power_quantity;
 
       /// Unit definition for yoctowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<-24> > >::type yoctowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<-24>>>::type yoctowatt_unit;
       /// Unit definition for zeptowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<-21> > >::type zeptowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<-21>>>::type zeptowatt_unit;
       /// Unit definition for attowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<-18> > >::type attowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<-18>>>::type attowatt_unit;
       /// Unit definition for femtowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<-15> > >::type femtowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<-15>>>::type femtowatt_unit;
       /// Unit definition for picowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<-12> > >::type picowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<-12>>>::type picowatt_unit;
       /// Unit definition for nanowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< -9> > >::type nanowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< -9>>>::type nanowatt_unit;
       /// Unit definition for microwatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< -6> > >::type microwatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< -6>>>::type microwatt_unit;
       /// Unit definition for milliwatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< -3> > >::type milliwatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< -3>>>::type milliwatt_unit;
       /// Unit definition for centiwatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< -2> > >::type centiwatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< -2>>>::type centiwatt_unit;
       /// Unit definition for deciwatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< -1> > >::type deciwatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< -1>>>::type deciwatt_unit;
       /// Unit definition for watt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  0> > >::type watt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  0>>>::type watt_unit;
       /// Unit definition for dekawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  1> > >::type dekawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  1>>>::type dekawatt_unit;
       /// Unit definition for decawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  1> > >::type decawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  1>>>::type decawatt_unit;
       /// Unit definition for hectowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  2> > >::type hectowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  2>>>::type hectowatt_unit;
       /// Unit definition for kilowatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  3> > >::type kilowatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  3>>>::type kilowatt_unit;
       /// Unit definition for megawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  6> > >::type megawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  6>>>::type megawatt_unit;
       /// Unit definition for gigawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational<  9> > >::type gigawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational<  9>>>::type gigawatt_unit;
       /// Unit definition for terawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< 12> > >::type terawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< 12>>>::type terawatt_unit;
       /// Unit definition for petawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< 15> > >::type petawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< 15>>>::type petawatt_unit;
       /// Unit definition for exawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< 18> > >::type exawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< 18>>>::type exawatt_unit;
       /// Unit definition for zettawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< 21> > >::type zettawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< 21>>>::type zettawatt_unit;
       /// Unit definition for yottawatt power.
-      typedef make_scaled_unit<si::power,scale<10,static_rational< 24> > >::type yottawatt_unit;
+      typedef make_scaled_unit<si::power,scale<10,static_rational< 24>>>::type yottawatt_unit;
 
       /// Numeric constant for yoctowatt.
       BOOST_UNITS_STATIC_CONSTANT(yoctowatt, yoctowatt_unit);

--- a/lib/ome/common/units/pressure.h
+++ b/lib/ome/common/units/pressure.h
@@ -78,49 +78,49 @@ namespace ome
       typedef quantity<si::pressure> pressure_quantity;
 
       /// Unit definition for yoctopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-24> > >::type yoctopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-24>>>::type yoctopascal_unit;
       /// Unit definition for zeptopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-21> > >::type zeptopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-21>>>::type zeptopascal_unit;
       /// Unit definition for attopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-18> > >::type attopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-18>>>::type attopascal_unit;
       /// Unit definition for femtopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-15> > >::type femtopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-15>>>::type femtopascal_unit;
       /// Unit definition for picopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-12> > >::type picopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<-12>>>::type picopascal_unit;
       /// Unit definition for nanopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -9> > >::type nanopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -9>>>::type nanopascal_unit;
       /// Unit definition for micropascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -6> > >::type micropascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -6>>>::type micropascal_unit;
       /// Unit definition for millipascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -3> > >::type millipascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -3>>>::type millipascal_unit;
       /// Unit definition for centipascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -2> > >::type centipascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -2>>>::type centipascal_unit;
       /// Unit definition for decipascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -1> > >::type decipascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< -1>>>::type decipascal_unit;
       /// Unit definition for pascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  0> > >::type pascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  0>>>::type pascal_unit;
       /// Unit definition for dekapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  1> > >::type dekapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  1>>>::type dekapascal_unit;
       /// Unit definition for decapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  1> > >::type decapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  1>>>::type decapascal_unit;
       /// Unit definition for hectopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  2> > >::type hectopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  2>>>::type hectopascal_unit;
       /// Unit definition for kilopascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  3> > >::type kilopascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  3>>>::type kilopascal_unit;
       /// Unit definition for megapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  6> > >::type megapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  6>>>::type megapascal_unit;
       /// Unit definition for gigapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  9> > >::type gigapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational<  9>>>::type gigapascal_unit;
       /// Unit definition for terapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 12> > >::type terapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 12>>>::type terapascal_unit;
       /// Unit definition for petapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 15> > >::type petapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 15>>>::type petapascal_unit;
       /// Unit definition for exapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 18> > >::type exapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 18>>>::type exapascal_unit;
       /// Unit definition for zettapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 21> > >::type zettapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 21>>>::type zettapascal_unit;
       /// Unit definition for yottapascal pressure.
-      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 24> > >::type yottapascal_unit;
+      typedef make_scaled_unit<si::pressure,scale<10,static_rational< 24>>>::type yottapascal_unit;
 
       /// Numeric constant for yoctopascal.
       BOOST_UNITS_STATIC_CONSTANT(yoctopascal, yoctopascal_unit);
@@ -258,23 +258,23 @@ namespace ome
       typedef quantity<yottapascal_unit> yottapascal_quantity;
 
       /// Unit definition for millibar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational< -3> > >::unit_type millibar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational< -3>>>::unit_type millibar_unit;
       /// Unit definition for centibar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational< -2> > >::unit_type centibar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational< -2>>>::unit_type centibar_unit;
       /// Unit definition for decibar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational< -1> > >::unit_type decibar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational< -1>>>::unit_type decibar_unit;
       /// Unit definition for bar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  0> > >::unit_type bar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  0>>>::unit_type bar_unit;
       /// Unit definition for dekabar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  1> > >::unit_type dekabar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  1>>>::unit_type dekabar_unit;
       /// Unit definition for decabar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  1> > >::unit_type decabar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  1>>>::unit_type decabar_unit;
       /// Unit definition for hectobar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  2> > >::unit_type hectobar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  2>>>::unit_type hectobar_unit;
       /// Unit definition for kilobar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  3> > >::unit_type kilobar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  3>>>::unit_type kilobar_unit;
       /// Unit definition for megabar pressure.
-      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  6> > >::unit_type megabar_unit;
+      typedef scaled_base_unit<boost::units::metric::bar_base_unit,scale<10,static_rational<  6>>>::unit_type megabar_unit;
 
       /// Numeric constant for millibar.
       BOOST_UNITS_STATIC_CONSTANT(millibar, millibar_unit);
@@ -360,7 +360,7 @@ namespace ome
       typedef quantity<torr_unit> torr_quantity;
 
       /// Unit definition for milliTorr pressure.
-      typedef scaled_base_unit<boost::units::metric::torr_base_unit,scale<10,static_rational< -3> > >::unit_type millitorr_unit;
+      typedef scaled_base_unit<boost::units::metric::torr_base_unit,scale<10,static_rational< -3>>>::unit_type millitorr_unit;
       /// Numeric constant for milliTorr.
       BOOST_UNITS_STATIC_CONSTANT(millitorr, millitorr_unit);
       /// Measured quantity in milliTorrs.

--- a/lib/ome/common/units/time.h
+++ b/lib/ome/common/units/time.h
@@ -72,49 +72,49 @@ namespace ome
       typedef quantity<si::time> time_quantity;
 
       /// Unit definition for yoctosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<-24> > >::type yoctosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<-24>>>::type yoctosecond_unit;
       /// Unit definition for zeptosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<-21> > >::type zeptosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<-21>>>::type zeptosecond_unit;
       /// Unit definition for attosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<-18> > >::type attosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<-18>>>::type attosecond_unit;
       /// Unit definition for femtosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<-15> > >::type femtosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<-15>>>::type femtosecond_unit;
       /// Unit definition for picosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<-12> > >::type picosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<-12>>>::type picosecond_unit;
       /// Unit definition for nanosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< -9> > >::type nanosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< -9>>>::type nanosecond_unit;
       /// Unit definition for microsecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< -6> > >::type microsecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< -6>>>::type microsecond_unit;
       /// Unit definition for millisecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< -3> > >::type millisecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< -3>>>::type millisecond_unit;
       /// Unit definition for centisecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< -2> > >::type centisecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< -2>>>::type centisecond_unit;
       /// Unit definition for decisecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< -1> > >::type decisecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< -1>>>::type decisecond_unit;
       /// Unit definition for second time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  0> > >::type second_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  0>>>::type second_unit;
       /// Unit definition for dekasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  1> > >::type dekasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  1>>>::type dekasecond_unit;
       /// Unit definition for decasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  1> > >::type decasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  1>>>::type decasecond_unit;
       /// Unit definition for hectosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  2> > >::type hectosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  2>>>::type hectosecond_unit;
       /// Unit definition for kilosecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  3> > >::type kilosecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  3>>>::type kilosecond_unit;
       /// Unit definition for megasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  6> > >::type megasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  6>>>::type megasecond_unit;
       /// Unit definition for gigasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational<  9> > >::type gigasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational<  9>>>::type gigasecond_unit;
       /// Unit definition for terasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< 12> > >::type terasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< 12>>>::type terasecond_unit;
       /// Unit definition for petasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< 15> > >::type petasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< 15>>>::type petasecond_unit;
       /// Unit definition for exasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< 18> > >::type exasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< 18>>>::type exasecond_unit;
       /// Unit definition for zettasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< 21> > >::type zettasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< 21>>>::type zettasecond_unit;
       /// Unit definition for yottasecond time.
-      typedef make_scaled_unit<si::time,scale<10,static_rational< 24> > >::type yottasecond_unit;
+      typedef make_scaled_unit<si::time,scale<10,static_rational< 24>>>::type yottasecond_unit;
 
       /// Numeric constant for yoctosecond.
       BOOST_UNITS_STATIC_CONSTANT(yoctosecond, yoctosecond_unit);

--- a/lib/ome/common/xml/EntityResolver.cpp
+++ b/lib/ome/common/xml/EntityResolver.cpp
@@ -230,13 +230,11 @@ namespace ome
                                   current.string()));
                 dom::Element root(doc.getDocumentElement());
                 dom::NodeList nodes(root.getChildNodes());
-                for (dom::NodeList::iterator i = nodes.begin();
-                     i != nodes.end();
-                     ++i)
+                for (auto& node : nodes)
                   {
-                    if (i->getNodeType() == xercesc::DOMNode::ELEMENT_NODE)
+                    if (node.getNodeType() == xercesc::DOMNode::ELEMENT_NODE)
                       {
-                        dom::Element e(i->get(), false);
+                        dom::Element e(node.get(), false);
                         if (e)
                           {
                             if (e.getTagName() == "uri")

--- a/lib/ome/common/xml/EntityResolver.h
+++ b/lib/ome/common/xml/EntityResolver.h
@@ -40,13 +40,12 @@
 #define OME_COMMON_XML_ENTITYRESOLVER_H
 
 #include <map>
+#include <memory>
 #include <string>
 
 #include <boost/filesystem/path.hpp>
 
 #include <ome/common/log.h>
-
-#include <ome/compat/memory.h>
 
 #include <xercesc/util/XMLEntityResolver.hpp>
 

--- a/lib/ome/common/xml/dom/Base.h
+++ b/lib/ome/common/xml/dom/Base.h
@@ -39,9 +39,9 @@
 #ifndef OME_COMMON_XML_DOM_BASE_H
 #define OME_COMMON_XML_DOM_BASE_H
 
-#include <ome/common/config.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/common/config.h>
 
 #include <iostream>
 #include <stdexcept>
@@ -97,8 +97,8 @@ namespace ome
           Base(base_element_type *wrapped,
                Deleter            del):
             base(wrapped ?
-                 ome::compat::shared_ptr<base_element_type>(wrapped, del) :
-                 ome::compat::shared_ptr<base_element_type>())
+                 std::shared_ptr<base_element_type>(wrapped, del) :
+                 std::shared_ptr<base_element_type>())
           {}
 
           /**
@@ -109,8 +109,8 @@ namespace ome
           explicit
           Base(base_element_type *wrapped):
             base(wrapped ?
-                 ome::compat::shared_ptr<base_element_type>(wrapped, &ome::common::xml::dom::detail::unmanaged<base_element_type>) :
-                 ome::compat::shared_ptr<base_element_type>())
+                 std::shared_ptr<base_element_type>(wrapped, &ome::common::xml::dom::detail::unmanaged<base_element_type>) :
+                 std::shared_ptr<base_element_type>())
           {}
 
           /// Destructor.
@@ -163,7 +163,7 @@ namespace ome
           reset()
           {
             base.reset();
-            ome::compat::shared_ptr<base_element_type> n;
+            std::shared_ptr<base_element_type> n;
             assign(n);
           }
 
@@ -201,7 +201,7 @@ namespace ome
            */
           virtual
           void
-          assign(ome::compat::shared_ptr<base_element_type>& wrapped)
+          assign(std::shared_ptr<base_element_type>& wrapped)
           {
             base = wrapped;
           }
@@ -228,7 +228,7 @@ namespace ome
 
         private:
           /// Wrapped reference.
-          ome::compat::shared_ptr<base_element_type> base;
+          std::shared_ptr<base_element_type> base;
         };
 
       }

--- a/lib/ome/common/xml/dom/Base.h
+++ b/lib/ome/common/xml/dom/Base.h
@@ -145,9 +145,9 @@ namespace ome
           }
 
           /**
-           * Check if the wrapped type is NULL.
+           * Check if the wrapped type is not null.
            *
-           * @returns true if valid, false if NULL.
+           * @returns true if not null, false if null.
            */
           operator bool () const
           {
@@ -155,9 +155,9 @@ namespace ome
           }
 
           /**
-           * Check if the wrapped type is NULL.
+           * Check if the wrapped type is null.
            *
-           * @returns true if valid, false if NULL.
+           * @returns true if null, false if not null.
            */
           bool
           operator == (std::nullptr_t) const
@@ -166,9 +166,9 @@ namespace ome
           }
 
           /**
-           * Check if the wrapped type is NULL.
+           * Check if the wrapped type is not null.
            *
-           * @returns true if valid, false if NULL.
+           * @returns true if not null, false if null.
            */
           bool
           operator != (std::nullptr_t) const
@@ -191,9 +191,9 @@ namespace ome
 
         protected:
           /**
-           * Check if the wrapped type is NULL.
+           * Check if the wrapped type is null.
            *
-           * @throws a @c std::logic_error if NULL.
+           * @throws a @c std::logic_error if null.
            */
           virtual
           void

--- a/lib/ome/common/xml/dom/Base.h
+++ b/lib/ome/common/xml/dom/Base.h
@@ -151,7 +151,29 @@ namespace ome
            */
           operator bool () const
           {
-            return get() != 0;
+            return get() != nullptr;
+          }
+
+          /**
+           * Check if the wrapped type is NULL.
+           *
+           * @returns true if valid, false if NULL.
+           */
+          bool
+          operator == (std::nullptr_t) const
+          {
+            return get() == nullptr;
+          }
+
+          /**
+           * Check if the wrapped type is NULL.
+           *
+           * @returns true if valid, false if NULL.
+           */
+          bool
+          operator != (std::nullptr_t) const
+          {
+            return get() != nullptr;
           }
 
           /**

--- a/lib/ome/common/xml/dom/Document.h
+++ b/lib/ome/common/xml/dom/Document.h
@@ -44,6 +44,7 @@
 #include <cassert>
 #include <functional>
 #include <istream>
+#include <memory>
 #include <string>
 #include <ostream>
 
@@ -54,7 +55,7 @@
 #include <xercesc/dom/DOMNode.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 
-#include <ome/compat/memory.h>
+#include <ome/common/filesystem.h>
 
 #include <ome/common/xml/dom/Element.h>
 #include <ome/common/xml/dom/NodeList.h>

--- a/lib/ome/common/xml/dom/NamedNodeMap.h
+++ b/lib/ome/common/xml/dom/NamedNodeMap.h
@@ -66,14 +66,14 @@ namespace ome
          * wrapped object.  It can also be cast to a pointer to the
          * wrapped object, so can substitute for it directly.
          */
-        class NamedNodeMap : public Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >
+        class NamedNodeMap : public Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap>>
         {
         public:
           /**
            * Construct a NULL NamedNodeMap.
            */
           NamedNodeMap ():
-            Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >()
+            Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap>>()
           {
           }
 
@@ -83,7 +83,7 @@ namespace ome
            * @param nodelist the NamedNodeMap to copy.
            */
           NamedNodeMap (const NamedNodeMap& nodelist):
-            Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >(nodelist)
+            Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap>>(nodelist)
           {
           }
 
@@ -93,7 +93,7 @@ namespace ome
            * @param nodelist the NamedNodeMap to wrap.
            */
           NamedNodeMap (xercesc::DOMNamedNodeMap *nodelist):
-            Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >(static_cast<base_element_type *>(nodelist))
+            Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap>>(static_cast<base_element_type *>(nodelist))
           {
           }
 

--- a/lib/ome/common/xml/dom/Node.h
+++ b/lib/ome/common/xml/dom/Node.h
@@ -67,7 +67,7 @@ namespace ome
          * object.  It can also be cast to a pointer to the wrapped
          * object, so can substitute for it directly.
          */
-        class Node : public Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode> >
+        class Node : public Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode>>
         {
         public:
           /// The derived object type of a node.
@@ -77,7 +77,7 @@ namespace ome
            * Construct a NULL Node.
            */
           Node ():
-            Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode> >()
+            Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode>>()
           {
           }
 
@@ -87,7 +87,7 @@ namespace ome
            * @param node the Node to copy.
            */
           Node (const Node& node):
-            Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode> >(node)
+            Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode>>(node)
           {
           }
 
@@ -99,9 +99,9 @@ namespace ome
            */
           Node (xercesc::DOMNode *node,
                 bool              managed):
-            Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode> >(managed ?
-                                                               Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode> >(node, std::mem_fun(&base_element_type::release)) :
-                                                               Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode> >(node, &ome::common::xml::dom::detail::unmanaged<base_element_type>))
+            Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode>>(managed ?
+                                                              Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode>>(node, std::mem_fun(&base_element_type::release)) :
+                                                              Wrapper<xercesc::DOMNode, Base<xercesc::DOMNode>>(node, &ome::common::xml::dom::detail::unmanaged<base_element_type>))
           {
           }
 

--- a/lib/ome/common/xml/dom/NodeList.cpp
+++ b/lib/ome/common/xml/dom/NodeList.cpp
@@ -58,7 +58,7 @@ namespace ome
                                       size_type             index):
           index(index),
           xmlnodelist(xmlnodelist),
-          xmlnode(ome::compat::shared_ptr<Node>(new Node(xmlnodelist->item(index), false)))
+          xmlnode(std::shared_ptr<Node>(new Node(xmlnodelist->item(index), false)))
         {}
 
         NodeList::iterator::iterator (const iterator& rhs):

--- a/lib/ome/common/xml/dom/NodeList.h
+++ b/lib/ome/common/xml/dom/NodeList.h
@@ -166,7 +166,7 @@ namespace ome
             /// List being iterated over.
             xercesc::DOMNodeList *xmlnodelist;
             /// Node at current position.
-            ome::compat::shared_ptr<Node> xmlnode;
+            std::shared_ptr<Node> xmlnode;
           };
 
           /**

--- a/lib/ome/common/xml/dom/NodeList.h
+++ b/lib/ome/common/xml/dom/NodeList.h
@@ -66,7 +66,7 @@ namespace ome
          * wrapped object.  It can also be cast to a pointer to the
          * wrapped object, so can substitute for it directly.
          */
-        class NodeList : public Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList> >
+        class NodeList : public Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList>>
         {
         public:
           /// The NodeList size type.
@@ -173,7 +173,7 @@ namespace ome
            * Construct a NULL NodeList.
            */
           NodeList ():
-            Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList> >()
+            Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList>>()
           {
           }
 
@@ -183,7 +183,7 @@ namespace ome
            * @param nodelist the NodeList to copy.
            */
           NodeList (const NodeList& nodelist):
-            Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList> >(nodelist)
+            Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList>>(nodelist)
           {
           }
 
@@ -193,7 +193,7 @@ namespace ome
            * @param nodelist the NodeList to wrap.
            */
           NodeList (xercesc::DOMNodeList *nodelist):
-            Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList> >(static_cast<base_element_type *>(nodelist))
+            Wrapper<xercesc::DOMNodeList, Base<xercesc::DOMNodeList>>(static_cast<base_element_type *>(nodelist))
           {
           }
 

--- a/lib/ome/common/xml/dom/Wrapper.h
+++ b/lib/ome/common/xml/dom/Wrapper.h
@@ -39,9 +39,9 @@
 #ifndef OME_COMMON_XML_DOM_WRAPPER_H
 #define OME_COMMON_XML_DOM_WRAPPER_H
 
-#include <ome/common/config.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/common/config.h>
 
 #include <ome/common/xml/dom/Base.h>
 
@@ -113,11 +113,11 @@ namespace ome
             parent_type(),
             wrapped()
           {
-            ome::compat::shared_ptr<base_element_type> pbase;
+            std::shared_ptr<base_element_type> pbase;
             if (base)
-              pbase = ome::compat::shared_ptr<base_element_type>(base, del);
+              pbase = std::shared_ptr<base_element_type>(base, del);
             else
-              pbase = ome::compat::shared_ptr<base_element_type>();
+              pbase = std::shared_ptr<base_element_type>();
             assign(pbase);
           }
 
@@ -131,11 +131,11 @@ namespace ome
             parent_type(),
             wrapped()
           {
-            ome::compat::shared_ptr<base_element_type> pbase;
+            std::shared_ptr<base_element_type> pbase;
             if (base)
-              pbase = ome::compat::shared_ptr<base_element_type>(base, &ome::common::xml::dom::detail::unmanaged<base_element_type>);
+              pbase = std::shared_ptr<base_element_type>(base, &ome::common::xml::dom::detail::unmanaged<base_element_type>);
             else
-              pbase = ome::compat::shared_ptr<base_element_type>();
+              pbase = std::shared_ptr<base_element_type>();
             assign(pbase);
           }
 
@@ -191,7 +191,7 @@ namespace ome
            */
           virtual
           void
-          assign(ome::compat::shared_ptr<base_element_type>& wrapped)
+          assign(std::shared_ptr<base_element_type>& wrapped)
           {
             this->wrapped = this->template assign_check<element_type>(wrapped.get());
             parent_type::assign(wrapped);

--- a/lib/ome/common/xsl/Platform.h
+++ b/lib/ome/common/xsl/Platform.h
@@ -39,9 +39,9 @@
 #ifndef OME_COMMON_XSL_PLATFORM_H
 #define OME_COMMON_XSL_PLATFORM_H
 
-#include <boost/thread.hpp>
+#include <cstdint>
 
-#include <ome/compat/cstdint.h>
+#include <boost/thread.hpp>
 
 #include <ome/common/xml/Platform.h>
 

--- a/lib/ome/compat/CMakeLists.txt
+++ b/lib/ome/compat/CMakeLists.txt
@@ -35,11 +35,8 @@
 # #L%
 
 set(ome_compat_headers
-    array.h
-    cstdint.h
     memory.h
-    regex.h
-    tuple.h)
+    regex.h)
 
 add_library(ome-compat INTERFACE)
 

--- a/lib/ome/compat/CMakeLists.txt
+++ b/lib/ome/compat/CMakeLists.txt
@@ -35,8 +35,11 @@
 # #L%
 
 set(ome_compat_headers
+    array.h
+    cstdint.h
     memory.h
-    regex.h)
+    regex.h
+    tuple.h)
 
 add_library(ome-compat INTERFACE)
 

--- a/lib/ome/compat/array.h
+++ b/lib/ome/compat/array.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2015 Open Microscopy Environment:
+ * Copyright © 2006 - 2017 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -39,10 +39,7 @@
 /**
  * @file ome/compat/array.h Array type substitution.
  *
- * This header substitutes Boost types for the same types in the std
- * namespace when not using a conforming C++11 compiler.  This permits
- * all code to use the C++11 standard types irrespective of the
- * compiler being used.
+ * @deprecated Use <array>.
  */
 
 #ifndef OME_COMPAT_ARRAY_H

--- a/lib/ome/compat/cstdint.h
+++ b/lib/ome/compat/cstdint.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2015 Open Microscopy Environment:
+ * Copyright © 2006 - 2017 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -38,6 +38,8 @@
 
 /**
  * @file ome/compat/cstdint.h Standard integer types.
+ *
+ * @deprecated Use <cstdint>.
  */
 
 #ifndef OME_COMPAT_CSTDINT_H

--- a/lib/ome/compat/memory.h
+++ b/lib/ome/compat/memory.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2015 Open Microscopy Environment:
+ * Copyright © 2006 - 2017 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -37,7 +37,9 @@
  */
 
 /**
- * @file ome/compat/memory.h Memory types.
+ * @file ome/compat/memory.h Memory type substitution.
+ *
+ * @deprecated Use <memory>.
  */
 
 #ifndef OME_COMPAT_MEMORY_H

--- a/lib/ome/compat/tuple.h
+++ b/lib/ome/compat/tuple.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2015 Open Microscopy Environment:
+ * Copyright © 2006 - 2017 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -37,7 +37,9 @@
  */
 
 /**
- * @file ome/compat/tuple.h Tuple types.
+ * @file ome/compat/tuple.h Tuple type substitution.
+ *
+ * @deprecated Use <tuple>.
  */
 
 #ifndef OME_COMPAT_TUPLE_H

--- a/test/ome-common/base64.cpp
+++ b/test/ome-common/base64.cpp
@@ -114,7 +114,7 @@ TEST_P(Base64Test, DecodeIter)
                              std::back_inserter(result));
   ASSERT_EQ(expected, result);
 
-  std::vector<uint8_t> result2 = ome::common::base64_decode<std::vector<uint8_t> >(params.encoded_data_exact);
+  std::vector<uint8_t> result2 = ome::common::base64_decode<std::vector<uint8_t>>(params.encoded_data_exact);
   ASSERT_EQ(expected, result2);
 }
 
@@ -125,23 +125,23 @@ TEST_P(Base64Test, DecodeVector)
   std::vector<uint8_t> expected(reinterpret_cast<const uint8_t *>(params.data),
                                 reinterpret_cast<const uint8_t *>(params.data + std::strlen(params.data)));
 
-  std::vector<uint8_t> result = ome::common::base64_decode<std::vector<uint8_t> >(params.encoded_data_inexact);
+  std::vector<uint8_t> result = ome::common::base64_decode<std::vector<uint8_t>>(params.encoded_data_inexact);
   ASSERT_EQ(expected, result);
 
-  std::vector<uint8_t> result2 = ome::common::base64_decode<std::vector<uint8_t> >(params.encoded_data_exact);
+  std::vector<uint8_t> result2 = ome::common::base64_decode<std::vector<uint8_t>>(params.encoded_data_exact);
   ASSERT_EQ(expected, result2);
 }
 
 TEST(Base64Test, DecodeFail)
 {
   // Premature end of input.
-  ASSERT_THROW(ome::common::base64_decode<std::vector<uint8_t> >("Invalid "), std::runtime_error);
+  ASSERT_THROW(ome::common::base64_decode<std::vector<uint8_t>>("Invalid "), std::runtime_error);
 
   // Invalid characters.
-  ASSERT_THROW(ome::common::base64_decode<std::vector<uint8_t> >("$#Invalid"), std::runtime_error);
+  ASSERT_THROW(ome::common::base64_decode<std::vector<uint8_t>>("$#Invalid"), std::runtime_error);
 
   // Data after padding.
-  ASSERT_THROW(ome::common::base64_decode<std::vector<uint8_t> >("VGVzdCBwYWRkaW5nLQ==VGVzdCBwYWRkaW5nLQ=="), std::runtime_error);
+  ASSERT_THROW(ome::common::base64_decode<std::vector<uint8_t>>("VGVzdCBwYWRkaW5nLQ==VGVzdCBwYWRkaW5nLQ=="), std::runtime_error);
 }
 
 TEST(Base64Test, LookupRoundTrip)
@@ -153,7 +153,7 @@ TEST(Base64Test, LookupRoundTrip)
       std::vector<uint8_t> input;
       input.push_back(static_cast<uint8_t>(i));
       std::string encoded = ome::common::base64_encode(input.begin(), input.end());
-      std::vector<uint8_t> decoded = ome::common::base64_decode<std::vector<uint8_t> >(encoded);
+      std::vector<uint8_t> decoded = ome::common::base64_decode<std::vector<uint8_t>>(encoded);
 
       ASSERT_EQ(input, decoded);
     }

--- a/test/ome-common/endian.cpp
+++ b/test/ome-common/endian.cpp
@@ -36,9 +36,9 @@
  * #L%
  */
 
-#include <ome/common/endian.h>
+#include <cstdint>
 
-#include <ome/compat/cstdint.h>
+#include <ome/common/endian.h>
 
 #include <ome/test/test.h>
 

--- a/test/ome-common/module.cpp
+++ b/test/ome-common/module.cpp
@@ -130,46 +130,47 @@ TEST_P(ModulePathTest, InvalidEnv)
       ASSERT_TRUE(params.logic_error);
     }
 }
-ModulePathTestParameters params[] =
+
+const std::vector<ModulePathTestParameters> params =
   {
-    ModulePathTestParameters("bin",          "OME_BINDIR",         false),
-    ModulePathTestParameters("sbin",         "OME_SBINDIR",        false),
-    ModulePathTestParameters("libexec",      "OME_LIBEXECDIR",     false),
-    ModulePathTestParameters("sysconf",      "OME_SYSCONFDIR",     false),
-    ModulePathTestParameters("sharedstate",  "OME_SHAREDSTATEDIR", false),
-    ModulePathTestParameters("localstate",   "OME_LOCALSTATEDIR",  false),
-    ModulePathTestParameters("lib",          "OME_LIBDIR",         false),
-    ModulePathTestParameters("include",      "OME_INCLUDEDIR",     false),
-    ModulePathTestParameters("oldinclude",   "OME_OLDINCLUDEDIR",  false),
-    ModulePathTestParameters("dataroot",     "OME_DATAROOTDIR",    false),
-    ModulePathTestParameters("data",         "OME_DATADIR",        false),
-    ModulePathTestParameters("info",         "OME_INFODIR",        false),
-    ModulePathTestParameters("locale",       "OME_LOCALEDIR",      false),
-    ModulePathTestParameters("man",          "OME_MANDIR",         false),
-    ModulePathTestParameters("doc",          "OME_DOCDIR",         false),
+    {"bin",             "OME_BINDIR",                false},
+    {"sbin",            "OME_SBINDIR",               false},
+    {"libexec",         "OME_LIBEXECDIR",            false},
+    {"sysconf",         "OME_SYSCONFDIR",            false},
+    {"sharedstate",     "OME_SHAREDSTATEDIR",        false},
+    {"localstate",      "OME_LOCALSTATEDIR",         false},
+    {"lib",             "OME_LIBDIR",                false},
+    {"include",         "OME_INCLUDEDIR",            false},
+    {"oldinclude",      "OME_OLDINCLUDEDIR",         false},
+    {"dataroot",        "OME_DATAROOTDIR",           false},
+    {"data",            "OME_DATADIR",               false},
+    {"info",            "OME_INFODIR",               false},
+    {"locale",          "OME_LOCALEDIR",             false},
+    {"man",             "OME_MANDIR",                false},
+    {"doc",             "OME_DOCDIR",                false},
 
-    ModulePathTestParameters("ome-common-root", "OME_HOME",        false),
+    {"ome-common-root", "OME_HOME",                  false},
 
-    ModulePathTestParameters("bin",          "OME_COMMON_BINDIR",         false),
-    ModulePathTestParameters("sbin",         "OME_COMMON_SBINDIR",        false),
-    ModulePathTestParameters("libexec",      "OME_COMMON_LIBEXECDIR",     false),
-    ModulePathTestParameters("sysconf",      "OME_COMMON_SYSCONFDIR",     false),
-    ModulePathTestParameters("sharedstate",  "OME_COMMON_SHAREDSTATEDIR", false),
-    ModulePathTestParameters("localstate",   "OME_COMMON_LOCALSTATEDIR",  false),
-    ModulePathTestParameters("lib",          "OME_COMMON_LIBDIR",         false),
-    ModulePathTestParameters("include",      "OME_COMMON_INCLUDEDIR",     false),
-    ModulePathTestParameters("oldinclude",   "OME_COMMON_OLDINCLUDEDIR",  false),
-    ModulePathTestParameters("dataroot",     "OME_COMMON_DATAROOTDIR",    false),
-    ModulePathTestParameters("data",         "OME_COMMON_DATADIR",        false),
-    ModulePathTestParameters("info",         "OME_COMMON_INFODIR",        false),
-    ModulePathTestParameters("locale",       "OME_COMMON_LOCALEDIR",      false),
-    ModulePathTestParameters("man",          "OME_COMMON_MANDIR",         false),
-    ModulePathTestParameters("doc",          "OME_COMMON_DOCDIR",         false),
+    {"bin",             "OME_COMMON_BINDIR",         false},
+    {"sbin",            "OME_COMMON_SBINDIR",        false},
+    {"libexec",         "OME_COMMON_LIBEXECDIR",     false},
+    {"sysconf",         "OME_COMMON_SYSCONFDIR",     false},
+    {"sharedstate",     "OME_COMMON_SHAREDSTATEDIR", false},
+    {"localstate",      "OME_COMMON_LOCALSTATEDIR",  false},
+    {"lib",             "OME_COMMON_LIBDIR",         false},
+    {"include",         "OME_COMMON_INCLUDEDIR",     false},
+    {"oldinclude",      "OME_COMMON_OLDINCLUDEDIR",  false},
+    {"dataroot",        "OME_COMMON_DATAROOTDIR",    false},
+    {"data",            "OME_COMMON_DATADIR",        false},
+    {"info",            "OME_COMMON_INFODIR",        false},
+    {"locale",          "OME_COMMON_LOCALEDIR",      false},
+    {"man",             "OME_COMMON_MANDIR",         false},
+    {"doc",             "OME_COMMON_DOCDIR",         false},
 
-    ModulePathTestParameters("ome-common-root", "OME_COMMON_HOME",        false),
+    {"ome-common-root", "OME_COMMON_HOME",           false},
 
     // Invalid dtype throws logic_error
-    ModulePathTestParameters("ome-files-invalid", "OME_INVALID",          true)
+    {"ome-files-invalid", "OME_INVALID",             true}
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;

--- a/test/ome-common/units.h
+++ b/test/ome-common/units.h
@@ -127,18 +127,16 @@ TYPED_TEST_P(UnitConv, Conversion)
 {
   std::cerr << "Testing unit conversion from " << this->from_name << " to " << this->to_name << " (" << this->ops.size() << " tests, precision=" << this->precision << ")\n";
 
-  for (typename std::vector<test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
+  for (const auto& op : this->ops)
     {
-      typename TypeParam::to_type obs(TypeParam::from_type::from_value(i->initial));
+      typename TypeParam::to_type obs(TypeParam::from_type::from_value(op.initial));
 
       // Use EXPECT_NEAR rather than EXPECT_DOUBLE_EQUAL due to
       // precision loss with angle conversions and pi, and unit
       // conversions between imperial and metric, and the worst
       // culprits are torr and mmHg conversion to Pa (in the mmHg
       // case, the constant used is of low precision)
-      EXPECT_NEAR(i->expected, quantity_cast<typename TypeParam::value_type>(obs), this->precision);
+      EXPECT_NEAR(op.expected, quantity_cast<typename TypeParam::value_type>(obs), this->precision);
     }
 }
 
@@ -146,11 +144,9 @@ TYPED_TEST_P(UnitConv, StreamOutput)
 {
   std::cerr << "Testing unit stream output from " << this->from_name << " to " << this->to_name << " (" << this->ops.size() << " tests)\n";
 
-  for (typename std::vector<test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
+  for (const auto& op : this->ops)
     {
-      typename TypeParam::to_type obs(TypeParam::from_type::from_value(i->initial));
+      typename TypeParam::to_type obs(TypeParam::from_type::from_value(op.initial));
 
       std::ostringstream os;
       os.imbue(std::locale::classic());
@@ -168,7 +164,7 @@ TYPED_TEST_P(UnitConv, StreamOutput)
 
       std::string obsstr_fixed(ome::compat::regex_replace(obsstr, repl, "e$1$2"));
 
-      EXPECT_EQ(i->expected_output, obsstr_fixed);
+      EXPECT_EQ(op.expected_output, obsstr_fixed);
     }
 }
 

--- a/test/ome-common/units.h
+++ b/test/ome-common/units.h
@@ -72,7 +72,7 @@ struct test_op
 };
 
 // From unit name, to unit name, test data
-typedef std::map<std::pair<std::string, std::string>, std::vector<test_op> > test_map;
+typedef std::map<std::pair<std::string, std::string>, std::vector<test_op>> test_map;
 
 extern test_map test_data;
 

--- a/test/ome-common/variant.cpp
+++ b/test/ome-common/variant.cpp
@@ -129,7 +129,7 @@ TEST(Variant, MPLVectorInteger)
 typedef boost::mpl::joint_view<non_numeric_types,
                                integer_types>::type joint_types_view;
 
-typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<> >::type, joint_types_view>::type joint_types;
+typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<>>::type, joint_types_view>::type joint_types;
 typedef boost::make_variant_over<joint_types>::type joint_variant;
 
 TEST(Variant, MPLVectorJointView)
@@ -147,8 +147,8 @@ struct make_vector
   typedef std::vector<T> type;
 };
 
-typedef boost::mpl::transform_view<joint_types_view, make_vector<boost::mpl::_1> >::type list_types_view;
-typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<> >::type, list_types_view>::type list_types;
+typedef boost::mpl::transform_view<joint_types_view, make_vector<boost::mpl::_1>>::type list_types_view;
+typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<>>::type, list_types_view>::type list_types;
 typedef boost::make_variant_over<list_types>::type list_variant;
 
 TEST(Variant, MPLVectorTransformList)
@@ -159,7 +159,7 @@ TEST(Variant, MPLVectorTransformList)
   strings.push_back("s3");
 
   list_variant v1(strings);
-  ASSERT_EQ(3U, boost::get<std::vector< std::string> >(v1).size());
+  ASSERT_EQ(3U, boost::get<std::vector< std::string>>(v1).size());
 
   std::vector<uint8_t> ints;
   ints.push_back(3);
@@ -168,5 +168,5 @@ TEST(Variant, MPLVectorTransformList)
   ints.push_back(43);
 
   list_variant v2(ints);
-  ASSERT_EQ(4U, boost::get<std::vector<uint8_t> >(v2).size());
+  ASSERT_EQ(4U, boost::get<std::vector<uint8_t>>(v2).size());
 }

--- a/test/ome-common/variant.cpp
+++ b/test/ome-common/variant.cpp
@@ -106,7 +106,7 @@ TEST(Variant, MPLVectorNonNumeric)
   ASSERT_FALSE(boost::get<bool>(v2));
 }
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 typedef boost::mpl::vector<uint8_t,
                            uint16_t,

--- a/test/ome-common/xerces.cpp
+++ b/test/ome-common/xerces.cpp
@@ -251,12 +251,12 @@ TEST_P(XercesTest, DocumentFromFile)
   if (params.valid)
     {
       ASSERT_NO_THROW(doc = ome::common::xml::dom::createDocument(boost::filesystem::path(params.filename), resolver));
-      ASSERT_TRUE(doc != 0);
+      ASSERT_TRUE(doc != nullptr);
     }
   else
     {
       ASSERT_THROW(doc = ome::common::xml::dom::createDocument(boost::filesystem::path(params.filename), resolver), std::runtime_error);
-      ASSERT_TRUE(doc == 0);
+      ASSERT_TRUE(doc == nullptr);
     }
 }
 
@@ -271,12 +271,12 @@ TEST_P(XercesTest, DocumentFromStream)
   if (params.valid)
     {
       ASSERT_NO_THROW(doc = ome::common::xml::dom::createDocument(in, resolver));
-      ASSERT_TRUE(doc != 0);
+      ASSERT_TRUE(doc != nullptr);
     }
   else
     {
       ASSERT_THROW(doc = ome::common::xml::dom::createDocument(in, resolver), std::runtime_error);
-      ASSERT_TRUE(doc == 0);
+      ASSERT_TRUE(doc == nullptr);
     }
 }
 
@@ -300,12 +300,12 @@ TEST_P(XercesTest, DocumentFromString)
   if (params.valid)
     {
       ASSERT_NO_THROW(doc = ome::common::xml::dom::createDocument(data, resolver));
-      ASSERT_TRUE(doc != 0);
+      ASSERT_TRUE(doc != nullptr);
     }
   else
     {
       ASSERT_THROW(doc = ome::common::xml::dom::createDocument(data, resolver), std::runtime_error);
-      ASSERT_TRUE(doc == 0);
+      ASSERT_TRUE(doc == nullptr);
     }
 }
 
@@ -318,10 +318,10 @@ TEST_P(XercesTest, ResetDocument)
       xml::dom::Document doc(ome::common::xml::dom::createDocument(boost::filesystem::path(params.filename), resolver));
 
       ASSERT_TRUE(doc);
-      ASSERT_TRUE(doc.get() != 0);
+      ASSERT_TRUE(doc.get() != nullptr);
       ASSERT_NO_THROW(doc.reset());
       ASSERT_FALSE(doc);
-      ASSERT_TRUE(doc.get() == 0);
+      ASSERT_TRUE(doc.get() == nullptr);
     }
 }
 

--- a/test/ome-common/xerces.cpp
+++ b/test/ome-common/xerces.cpp
@@ -619,13 +619,13 @@ TEST_P(XercesTest, NodeWriteStream)
     }
 }
 
-XercesTestParameters params[] =
+const std::vector<XercesTestParameters> params =
   {
-    //    XercesTestParameters(PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::NONE),
-    XercesTestParameters(PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::FILES, true),
-    XercesTestParameters(PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::CATALOG, true),
-    XercesTestParameters(PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid.ome", XercesTestParameters::CATALOG, false),
-    XercesTestParameters(PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid2.ome", XercesTestParameters::CATALOG, false)
+    // { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::NONE },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::FILES, true },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::CATALOG, true },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid.ome", XercesTestParameters::CATALOG, false },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid2.ome", XercesTestParameters::CATALOG, false }
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;

--- a/test/ome-common/xerces.cpp
+++ b/test/ome-common/xerces.cpp
@@ -54,7 +54,7 @@ namespace xml = ome::common::xml;
 class XercesTestParameters
 {
 public:
-  enum Resolver
+  enum class Resolver
     {
       NONE,
       FILES,
@@ -85,7 +85,7 @@ public:
   {
     const XercesTestParameters& params = GetParam();
 
-    if (params.resolver == XercesTestParameters::FILES)
+    if (params.resolver == XercesTestParameters::Resolver::FILES)
       {
         resolver.registerEntity("http://www.w3.org/2001/XMLSchema",
                                boost::filesystem::path(PROJECT_SOURCE_DIR "/test/ome-common/data/schema/external/XMLSchema.xsd"));
@@ -108,7 +108,7 @@ public:
         resolver.registerEntity("http://www.openmicroscopy.org/Schemas/ROI/2012-06/ROI.xsd",
                                 boost::filesystem::path(PROJECT_SOURCE_DIR "/test/ome-common/data/schema/2012-06/ROI.xsd"));
       }
-    else if (params.resolver == XercesTestParameters::CATALOG)
+    else if (params.resolver == XercesTestParameters::Resolver::CATALOG)
       {
         resolver.registerCatalog(boost::filesystem::path(PROJECT_SOURCE_DIR "/test/ome-common/data/schema/catalog.xml"));
       }
@@ -621,11 +621,11 @@ TEST_P(XercesTest, NodeWriteStream)
 
 const std::vector<XercesTestParameters> params =
   {
-    // { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::NONE },
-    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::FILES, true },
-    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::CATALOG, true },
-    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid.ome", XercesTestParameters::CATALOG, false },
-    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid2.ome", XercesTestParameters::CATALOG, false }
+    // { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::Resolver::NONE },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::Resolver::FILES, true },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text.ome", XercesTestParameters::Resolver::CATALOG, true },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid.ome", XercesTestParameters::Resolver::CATALOG, false },
+    { PROJECT_SOURCE_DIR "/test/ome-common/data/18x24y5z5t2c8b-text-invalid2.ome", XercesTestParameters::Resolver::CATALOG, false }
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;

--- a/test/ome-compat/array.cpp
+++ b/test/ome-compat/array.cpp
@@ -36,13 +36,13 @@
  * #L%
  */
 
-#include <ome/compat/array.h>
+#include <array>
 
 #include <ome/test/test.h>
 
 TEST(Array, DefaultConstruct)
 {
-  ome::compat::array<int, 10> a;
+  std::array<int, 10> a;
   // We're not explicitly testing here, but it squashed an unused
   // variable compiler warning.
   a[0] = 0;
@@ -51,7 +51,7 @@ TEST(Array, DefaultConstruct)
 
 TEST(Array, Assign)
 {
-  ome::compat::array<int, 10> a;
+  std::array<int, 10> a;
   a[4] = 453;
   ASSERT_EQ(a[4], 453);
 }

--- a/test/ome-compat/cstdint.cpp
+++ b/test/ome-compat/cstdint.cpp
@@ -36,7 +36,7 @@
  * #L%
  */
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/test/test.h>
 

--- a/test/ome-compat/memory.cpp
+++ b/test/ome-compat/memory.cpp
@@ -36,7 +36,7 @@
  * #L%
  */
 
-#include <ome/compat/memory.h>
+#include <memory>
 
 #include <ome/test/test.h>
 
@@ -58,77 +58,77 @@ public:
   virtual ~fail() {}
 };
 
-class cshared : public ome::compat::enable_shared_from_this<cshared>
+class cshared : public std::enable_shared_from_this<cshared>
 {
 public:
 public:
   virtual ~cshared() {}
 
-  ome::compat::shared_ptr<cshared>
+  std::shared_ptr<cshared>
   getptr()
   { return shared_from_this(); }
 };
 
 TEST(Memory, CreateShared)
 {
-  ome::compat::shared_ptr<inh> p(ome::compat::make_shared<inh>());
+  std::shared_ptr<inh> p(std::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(p));
 }
 
 TEST(Memory, CreateWeak)
 {
-  ome::compat::shared_ptr<inh> p(ome::compat::make_shared<inh>());
+  std::shared_ptr<inh> p(std::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(p));
 
-  ome::compat::shared_ptr<inh> w(p);
-  ome::compat::shared_ptr<inh> p2(w);
+  std::shared_ptr<inh> w(p);
+  std::shared_ptr<inh> p2(w);
   ASSERT_TRUE(static_cast<bool>(p2));
 }
 
 TEST(Memory, StaticPointerCast)
 {
-  ome::compat::shared_ptr<inh> p(ome::compat::make_shared<inh>());
+  std::shared_ptr<inh> p(std::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(p));
 
-  ome::compat::shared_ptr<base> b(ome::compat::static_pointer_cast<base>(p));
+  std::shared_ptr<base> b(std::static_pointer_cast<base>(p));
   ASSERT_TRUE(static_cast<bool>(b));
 }
 
 TEST(Memory, DynamicPointerCast)
 {
-  ome::compat::shared_ptr<base> b(ome::compat::make_shared<inh>());
+  std::shared_ptr<base> b(std::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(b));
 
-  ome::compat::shared_ptr<inh> p = ome::compat::dynamic_pointer_cast<inh>(b);
+  std::shared_ptr<inh> p = std::dynamic_pointer_cast<inh>(b);
   ASSERT_TRUE(static_cast<bool>(p));
 }
 
 TEST(Memory, DynamicPointerCastFail)
 {
-  ome::compat::shared_ptr<base> b(ome::compat::make_shared<inh>());
+  std::shared_ptr<base> b(std::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(b));
 
-  ome::compat::shared_ptr<fail> f = ome::compat::dynamic_pointer_cast<fail>(b);
+  std::shared_ptr<fail> f = std::dynamic_pointer_cast<fail>(b);
   ASSERT_FALSE(static_cast<bool>(f));
 }
 
 TEST(Memory, ConstPointerCast)
 {
-  ome::compat::shared_ptr<base> b(ome::compat::make_shared<inh>());
+  std::shared_ptr<base> b(std::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(b));
 
-  ome::compat::shared_ptr<const base> c = ome::compat::const_pointer_cast<base>(b);
+  std::shared_ptr<const base> c = std::const_pointer_cast<base>(b);
   ASSERT_TRUE(static_cast<bool>(c));
 }
 
 TEST(Memory, EnableSharedFromThis)
 {
-  ome::compat::shared_ptr<cshared> c(ome::compat::make_shared<cshared>());
+  std::shared_ptr<cshared> c(std::make_shared<cshared>());
   ASSERT_TRUE(static_cast<bool>(c));
   ASSERT_EQ(c.use_count(), 1);
 
   {
-    ome::compat::shared_ptr<cshared> c2 = c->getptr();
+    std::shared_ptr<cshared> c2 = c->getptr();
     ASSERT_TRUE(static_cast<bool>(c2));
     ASSERT_EQ(c.use_count(), 2);
     ASSERT_EQ(c2.use_count(), 2);

--- a/test/ome-compat/tuple.cpp
+++ b/test/ome-compat/tuple.cpp
@@ -36,21 +36,21 @@
  * #L%
  */
 
-#include <ome/compat/tuple.h>
+#include <tuple>
 
 #include <ome/test/test.h>
 
 TEST(Tuple, Create)
 {
-  typedef ome::compat::tuple<int,double,std::string> t1;
+  typedef std::tuple<int,double,std::string> t1;
   t1 i(34, 2342.23, "test");
 }
 
 TEST(Tuple, Get)
 {
-  typedef ome::compat::tuple<int,std::string> t2;
+  typedef std::tuple<int,std::string> t2;
   t2 i(34, "test");
 
-  ASSERT_EQ(ome::compat::get<0>(i), 34);
-  ASSERT_EQ(ome::compat::get<1>(i), "test");
+  ASSERT_EQ(std::get<0>(i), 34);
+  ASSERT_EQ(std::get<1>(i), "test");
 }


### PR DESCRIPTION
Next part of [Minimal C++11 features](https://trello.com/c/h4pHPV2h/42-minimal-c-11-features).  This PR switches to using a few simple C++11 features.

- Use `<array>`, `<cstdint>`, `<memory>` and `<tuple>` in place of `<ome/compat/array.h>`, `<ome/compat/cstdint.h>`, `<ome/compat/memory.h>` and `<ome/compat/tuple.h>`, respectively (with namespace change from `ome::compat` to `std` for the corresponding types)
- Use `>>` in place of `> >` in templates (spaces previously required)
- Use initialiser lists when constructing objects, mainly containers.  This uses `foo{elem1, elem2, elemn}` in place of `foo` to directly fill containers with elements.  Mainly used with parameterised test data which had to use static arrays as the data source.
- Use range-based for loop and `auto` type rather than manually define complex iterator types and manually iterate; this greatly simplifies `for` loops
- Use `enum class` to scope enum values; previously they leaked into the enclosing scope
- Deprecate compatibility headers (in doxygen comments)

The compatibility headers were removed to test that all downstream `basic-c++11` branches in ome-model, ome-files and ome-qtwidgets components were using only the standard headers, then added back.  The downstream components continue to build with this PR alone, demonstrating that the compatibility headers continue to function, and that nothing breaks as a result of the changes here.

This will be followed by opening PRs against the downstream components in sequence.  Some additional features such as `<thread>` usage will be done in later PRs.

--------

Testing: Check all builds are green.