### PR TITLE
Correct doxygen warnings

### DIFF
--- a/lib/ome/compat/array.h
+++ b/lib/ome/compat/array.h
@@ -39,7 +39,7 @@
 /**
  * @file ome/compat/array.h Array type substitution.
  *
- * @deprecated Use <array>.
+ * @deprecated Use the standard @c array header.
  */
 
 #ifndef OME_COMPAT_ARRAY_H

--- a/lib/ome/compat/cstdint.h
+++ b/lib/ome/compat/cstdint.h
@@ -39,7 +39,7 @@
 /**
  * @file ome/compat/cstdint.h Standard integer types.
  *
- * @deprecated Use <cstdint>.
+ * @deprecated Use the standard @c cstdint header.
  */
 
 #ifndef OME_COMPAT_CSTDINT_H

--- a/lib/ome/compat/memory.h
+++ b/lib/ome/compat/memory.h
@@ -39,7 +39,7 @@
 /**
  * @file ome/compat/memory.h Memory type substitution.
  *
- * @deprecated Use <memory>.
+ * @deprecated Use the standard @c memory header.
  */
 
 #ifndef OME_COMPAT_MEMORY_H

--- a/lib/ome/compat/tuple.h
+++ b/lib/ome/compat/tuple.h
@@ -39,7 +39,7 @@
 /**
  * @file ome/compat/tuple.h Tuple type substitution.
  *
- * @deprecated Use <tuple>.
+ * @deprecated Use the standard @c tuple header.
  */
 
 #ifndef OME_COMPAT_TUPLE_H


### PR DESCRIPTION
Minor markup corrections for the upcoming release.  This removes four warnings at build time (it thinks the `<` and `>` symbols are HTML markup.

Testing: Check the build log and doxygen docs.