### PR TITLE
Prepare ome-common-cpp 5.4.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_MODULE_PATH
      "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 set(release-name "ome-common-cpp")
-set(release-version "5.4.0")
+set(release-version "5.4.1")
 project(ome-common
         VERSION "${release-version}"
         LANGUAGES CXX)


### PR DESCRIPTION
Discussed with @rleigh-codelibre following the changes in https://github.com/ome/ome-common-cpp/pull/32 and related PRs for the OME Files 0.3.0 release.

This version bump is the C++ equivalent of the SNAPSHOT bump PR of the Maven/Java components  and should follow every component release. As there is currently no upstream CMake logic/convention for handling development versions, the `cmake/Versions.cmake` adds the necessary logic by using `git describe` logic for in-tree builds to derive a `x.y.y-DEV` version number.

To test this PR, check the OME Files CI job source archiving create `5.4.1-DEV*` artifacts.

Once we agree on the behavior, I will open companion PRs in the other repositories and codify the policy it a contributing page for the C++ components.