### PR TITLE
build gtest from source as part of the project build

### DIFF
--- a/cmake/GTest.cmake
+++ b/cmake/GTest.cmake
@@ -38,14 +38,52 @@ enable_testing()
 option(test "Enable unit tests (requires gtest)" ON)
 set(BUILD_TESTS ${test})
 set(EXTENDED_TESTS ${extended-tests})
+set(GTEST_SRC_DIR "/usr/src/googletest/googletest/")
 
 # Unit tests
 find_package(Threads REQUIRED)
 
 if(BUILD_TESTS)
-  find_package(GTest)
-  if(NOT GTEST_FOUND)
-    message(WARNING "GTest not found; tests disabled")
-    set(BUILD_TESTS OFF)
+  if(EXISTS ${GTEST_SRC_DIR})
+    ## Upstream recommends against using precompiled libraries and
+    ## installation of gtest.  Instead, each project should compile
+    ## gtest itself from local sources.  See issue #42.
+    include(ExternalProject)
+    message(STATUS "Using googletest at ${GTEST_SRC_DIR} as external project")
+    ExternalProject_Add(GTest
+      SOURCE_DIR ${GTEST_SRC_DIR}
+      PREFIX "${CMAKE_CURRENT_BINARY_DIR}/GTest"
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND ""
+      TEST_COMMAND ""
+      )
+    ExternalProject_Get_Property(GTest SOURCE_DIR BINARY_DIR)
+
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" ${SOURCE_DIR}
+      RESULT_VARIABLE gtest_cmake_result
+      WORKING_DIRECTORY ${BINARY_DIR})
+    if(gtest_cmake_result)
+      message(FATAL_ERROR "CMake of GTest failed: ${gtest_cmake_result}")
+    endif()
+
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+      RESULT_VARIABLE gtest_cmake_result
+      WORKING_DIRECTORY ${BINARY_DIR})
+    if(gtest_cmake_result)
+      message(FATAL_ERROR "Build of GTest failed: ${gtest_cmake_result}")
+    endif()
+
+    ## This adds the gtest and gtest_main targets...
+    add_subdirectory(${SOURCE_DIR} ${BINARY_DIR})
+    ## but the project expects GTest::GTest which is what would be
+    ## imported if we were using find_package(GTest)
+    add_library(GTest::GTest ALIAS gtest)
+  else()
+    find_package(GTest)
+    if(NOT GTEST_FOUND)
+      message(WARNING "GTest not found; tests disabled")
+      set(BUILD_TESTS OFF)
+    endif()
   endif()
 endif()

--- a/cmake/GTest.cmake
+++ b/cmake/GTest.cmake
@@ -74,8 +74,10 @@ if(BUILD_TESTS)
       message(FATAL_ERROR "Build of GTest failed: ${gtest_cmake_result}")
     endif()
 
-    ## This adds the gtest and gtest_main targets...
-    add_subdirectory(${SOURCE_DIR} ${BINARY_DIR})
+    ## This adds the gtest and gtest_main targets (but not to ALL
+    ## because we don't want to install gtest) ...
+    add_subdirectory(${SOURCE_DIR} ${BINARY_DIR}
+      EXCLUDE_FROM_ALL)
     ## but the project expects GTest::GTest which is what would be
     ## imported if we were using find_package(GTest)
     add_library(GTest::GTest ALIAS gtest)


### PR DESCRIPTION
As per upstream recommendation, this builds gtest from source as part of the build. Fixes #42 