### PR TITLE
Use C++11 <thread> and <mutex>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/BoostChecks.cmake
+++ b/cmake/BoostChecks.cmake
@@ -40,7 +40,7 @@ set(Boost_USE_STATIC_LIBS OFF)
 
 find_package(Boost 1.54 REQUIRED
              COMPONENTS date_time filesystem system iostreams
-                        log log_setup program_options regex thread)
+                        log log_setup program_options regex)
 
 include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)

--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/DoxygenCheck.cmake
+++ b/cmake/DoxygenCheck.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/GTest.cmake
+++ b/cmake/GTest.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/HeaderTest.cmake
+++ b/cmake/HeaderTest.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/PlatformChecks.cmake
+++ b/cmake/PlatformChecks.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2014 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/RegexChecks.cmake
+++ b/cmake/RegexChecks.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/ThreadChecks.cmake
+++ b/cmake/ThreadChecks.cmake
@@ -1,7 +1,7 @@
 # #%L
 # OME C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2015 Open Microscopy Environment:
+# Copyright © 2006 - 2017 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cmake/ThreadChecks.cmake
+++ b/cmake/ThreadChecks.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/ThreadChecks.cmake
+++ b/cmake/ThreadChecks.cmake
@@ -78,4 +78,8 @@ STD_THREAD_FUNCTIONAL)
   endif()
 endfunction(thread_test)
 
-thread_test()
+# Earlier CMake versions don't set the language standard when running
+# feature tests.
+if(NOT CMAKE_VERSION VERSION_LESS 3.8)
+  thread_test()
+endif()

--- a/cmake/ThreadChecks.cmake
+++ b/cmake/ThreadChecks.cmake
@@ -38,54 +38,44 @@ include(CheckCXXSourceRuns)
 
 find_package(Threads REQUIRED)
 
-function(thread_test namespace header library outvar outlib)
-  set(CMAKE_REQUIRED_DEFINITIONS_SAVE ${CMAKE_REQUIRED_DEFINITIONS})
-  set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB)
-  set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
-  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${Boost_INCLUDE_DIRS})
+function(thread_test)
   set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
   set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${library} ${CMAKE_THREAD_LIBS_INIT})
 
   check_cxx_source_runs(
-"#include <${header}>
+"#include <mutex>
+#include <thread>
 #include <iostream>
 
 namespace
 {
 
-  boost::mutex m1;
-  boost::recursive_mutex m2;
+  std::mutex m1;
+  std::recursive_mutex m2;
 
   void
   threadmain()
   {
-    boost::lock_guard<boost::mutex> lock1(m1);
-    boost::lock_guard<boost::recursive_mutex> lock2(m2);
+    std::lock_guard<std::mutex> lock1(m1);
+    std::lock_guard<std::recursive_mutex> lock2(m2);
     std::cout << \"In thread\" << std::endl;
   }
 
 }
 
 int main() {
-  ${namespace} foo(threadmain);
+  std::thread foo(threadmain);
   foo.join();
 
   return 0;
 }"
-${outvar})
+STD_THREAD_FUNCTIONAL)
 
   set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_SAVE})
-  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVE})
-  set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS_SAVE})
 
-  set(${outvar} ${${outvar}} PARENT_SCOPE)
-  if (${outvar})
-    set(${outlib} ${library} PARENT_SCOPE)
-  endif(${outvar})
+  if(NOT STD_THREAD_FUNCTIONAL)
+    message(FATAL_ERROR "No working thread or mutex implementation found")
+  endif()
 endfunction(thread_test)
 
-
-thread_test(boost::thread boost/thread.hpp "${Boost_SYSTEM_LIBRARY_RELEASE};${Boost_THREAD_LIBRARY_RELEASE}" OME_HAVE_BOOST_THREAD THREAD_LIBRARY)
-if(NOT OME_HAVE_BOOST_THREAD)
-  message(FATAL_ERROR "No working thread or mutex implementation found")
-endif(NOT OME_HAVE_BOOST_THREAD)
+thread_test()

--- a/cmake/XalanChecks.cmake
+++ b/cmake/XalanChecks.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/cmake/XercesChecks.cmake
+++ b/cmake/XercesChecks.cmake
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/lib/ome/common/CMakeLists.txt
+++ b/lib/ome/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/lib/ome/common/CMakeLists.txt
+++ b/lib/ome/common/CMakeLists.txt
@@ -130,6 +130,7 @@ target_include_directories(ome-common PUBLIC
 
 target_link_libraries(ome-common
                       PUBLIC
+                      Threads::Threads
                       OME::Compat
                       Boost::log_setup
                       Boost::log

--- a/lib/ome/common/OMECommonConfig.cmake.in
+++ b/lib/ome/common/OMECommonConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(OMECompat REQUIRED)
 find_dependency(Boost 1.46 REQUIRED
                 COMPONENTS date_time filesystem system iostreams
-                program_options regex thread)
+                program_options regex)
 find_dependency(XercesC 3.0.0 REQUIRED)
 find_dependency(XalanC 1.10 REQUIRED)
 

--- a/lib/ome/common/config.h.in
+++ b/lib/ome/common/config.h.in
@@ -44,7 +44,6 @@
 #cmakedefine OME_HAVE_REGEX 1
 #cmakedefine OME_HAVE_TR1_REGEX 1
 #cmakedefine OME_HAVE_BOOST_REGEX 1
-#cmakedefine OME_HAVE_BOOST_THREAD 1
 #cmakedefine OME_HAVE_SNPRINTF 1
 #cmakedefine OME_VARIANT_LIMIT 1
 #cmakedefine OME_HAVE_DLADDR 1

--- a/lib/ome/common/module.cpp
+++ b/lib/ome/common/module.cpp
@@ -480,7 +480,7 @@ namespace ome
                 }
             }
         }
-      boost::format fmt("Could not determine Bio-Formats runtime path for “%1%” directory");
+      boost::format fmt("Could not determine runtime path for “%1%” directory");
       fmt % dtype;
       throw std::runtime_error(fmt.str());
     }

--- a/lib/ome/common/xml/Platform.cpp
+++ b/lib/ome/common/xml/Platform.cpp
@@ -45,7 +45,7 @@ namespace ome
     namespace xml
     {
 
-      boost::mutex Platform::mutex;
+      std::mutex Platform::mutex;
 
     }
   }

--- a/lib/ome/common/xml/Platform.h
+++ b/lib/ome/common/xml/Platform.h
@@ -39,7 +39,7 @@
 #ifndef OME_COMMON_XML_PLATFORM_H
 #define OME_COMMON_XML_PLATFORM_H
 
-#include <boost/thread.hpp>
+#include <mutex>
 
 #include <xercesc/util/PlatformUtils.hpp>
 
@@ -76,7 +76,7 @@ namespace ome
          */
         Platform()
         {
-	  boost::lock_guard<boost::mutex> lock(mutex);
+	  std::lock_guard<std::mutex> lock(mutex);
 
           xercesc::XMLPlatformUtils::Initialize();
         }
@@ -87,13 +87,13 @@ namespace ome
         inline
         ~Platform()
         {
-	  boost::lock_guard<boost::mutex> lock(mutex);
+	  std::lock_guard<std::mutex> lock(mutex);
 
           xercesc::XMLPlatformUtils::Terminate();
         }
 
 	/// Mutex to lock libxerces access.
-        static boost::mutex mutex;
+        static std::mutex mutex;
       };
 
     }

--- a/lib/ome/common/xsl/Platform.cpp
+++ b/lib/ome/common/xsl/Platform.cpp
@@ -45,7 +45,7 @@ namespace ome
     namespace xsl
     {
 
-      boost::mutex Platform::mutex;
+      std::mutex Platform::mutex;
 
       uint32_t Platform::refcount = 0;
 

--- a/lib/ome/common/xsl/Platform.h
+++ b/lib/ome/common/xsl/Platform.h
@@ -41,7 +41,7 @@
 
 #include <cstdint>
 
-#include <boost/thread.hpp>
+#include <mutex>
 
 #include <ome/common/xml/Platform.h>
 
@@ -90,7 +90,7 @@ namespace ome
 	  xmlplatform(),
           skip(skip)
         {
-	  boost::lock_guard<boost::mutex> lock(mutex);
+	  std::lock_guard<std::mutex> lock(mutex);
 
           // Only call initialize for first instance.
           if (refcount == 0 && !skip)
@@ -103,7 +103,7 @@ namespace ome
          */
         ~Platform()
         {
-	  boost::lock_guard<boost::mutex> lock(mutex);
+	  std::lock_guard<std::mutex> lock(mutex);
 
           // Only call terminate for last instance.
           // refcount will never be zero at this point.
@@ -118,7 +118,7 @@ namespace ome
         /// Skip initialize and terminate calls.
         bool skip;
         /// Mutex to lock libxalan access.
-        static boost::mutex mutex;
+        static std::mutex mutex;
         /// Reference count.
         static uint32_t refcount;
       };

--- a/lib/ome/compat/CMakeLists.txt
+++ b/lib/ome/compat/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/lib/ome/test/CMakeLists.txt
+++ b/lib/ome/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/lib/ome/test/io.cpp
+++ b/lib/ome/test/io.cpp
@@ -1,6 +1,6 @@
 /*
  * #%L
- * # Bio-Formats C++ libraries (test infrastructure)
+ * # OME C++ libraries (test infrastructure)
  * %%
  * Copyright © 2013 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/lib/ome/test/main.cpp
+++ b/lib/ome/test/main.cpp
@@ -1,6 +1,6 @@
 /*
  * #%L
- * # Bio-Formats C++ libraries (test infrastructure)
+ * # OME C++ libraries (test infrastructure)
  * %%
  * Copyright © 2013 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/test/ome-common/CMakeLists.txt
+++ b/test/ome-common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology

--- a/test/ome-common/CMakeLists.txt
+++ b/test/ome-common/CMakeLists.txt
@@ -77,7 +77,7 @@ if(BUILD_TESTS)
   ome_add_test(ome-common/mstream mstream)
 
   add_executable(thread thread.cpp)
-  target_link_libraries(thread OME::Common ${THREAD_LIBRARY})
+  target_link_libraries(thread OME::Common Threads::Threads)
   target_link_libraries(thread OME::Test)
 
   ome_add_test(ome-common/thread thread)

--- a/test/ome-common/thread.cpp
+++ b/test/ome-common/thread.cpp
@@ -36,7 +36,9 @@
  * #L%
  */
 
-#include <boost/thread.hpp>
+#include <functional>
+#include <mutex>
+#include <thread>
 
 #include <ome/test/test.h>
 
@@ -54,7 +56,7 @@ namespace
     int a;
     int b;
     int value;
-    boost::mutex value_guard;
+    std::mutex value_guard;
 
   public:
     threadtest2(int a, int b):
@@ -66,13 +68,13 @@ namespace
 
     void operator() ()
     {
-      boost::lock_guard<boost::mutex> lock(value_guard);
+      std::lock_guard<std::mutex> lock(value_guard);
       value = a + b;
     }
 
     int result()
     {
-      boost::lock_guard<boost::mutex> lock(value_guard);
+      std::lock_guard<std::mutex> lock(value_guard);
       return value;
     }
   };
@@ -81,15 +83,16 @@ namespace
 
 TEST(Mutex, LockGuard)
 {
-  boost::mutex m;
-  boost::lock_guard<boost::mutex> lock(m);
+  std::mutex m;
+  std::lock_guard<std::mutex> lock(m);
 }
 
 // Create thread from bare function.  Note: Could also have been a
 // static class method.
 TEST(Thread, Function)
 {
-  boost::thread foo(threadtest1);
+  std::thread foo(threadtest1);
+  foo.join();
 }
 
 // Create thread from function object.  Check state after join and use
@@ -98,9 +101,9 @@ TEST(Thread, Object)
 {
   threadtest2 t(4,55);
 
-  // Note that boost::ref avoids a copy of the functor so the result
+  // Note that std::ref avoids a copy of the functor so the result
   // is set in the same object.
-  boost::thread foo(boost::ref(t));
+  std::thread foo(std::ref(t));
   foo.join();
 
   ASSERT_EQ(59, t.result());

--- a/test/ome-compat/CMakeLists.txt
+++ b/test/ome-compat/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #%L
-# Bio-Formats C++ libraries (cmake build infrastructure)
+# OME C++ libraries (cmake build infrastructure)
 # %%
 # Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology


### PR DESCRIPTION
This is part of [this card](https://trello.com/c/h4pHPV2h/42-minimal-c11-features) which we did not have time for in January.

This is a straightforward replacement of Boost.Thread with standard thread and mutex classes.  This is a followup item for the C++11 adoption six months back, and will allow for the future removal of Boost.Thread as a dependency (not immediately; it's still a transitive dependency of Boost.Filesystem).  When we allow the use C++17 std::filesystem as an alternative to Boost.Filesystem, it will no longer be linked.

Testing: Check builds remain green.  There's nothing specific to test other than that; if it builds and passes the tests, it's working.