### PR TITLE
cmake: FindBoost: Add support for Boost 1.65.1

### DIFF
--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -1023,7 +1023,7 @@ else()
   # _Boost_COMPONENT_HEADERS.  See the instructions at the top of
   # _Boost_COMPONENT_DEPENDENCIES.
   set(_Boost_KNOWN_VERSIONS ${Boost_ADDITIONAL_VERSIONS}
-    "1.65.0" "1.65"
+    "1.65.1" "1.65.0" "1.65"
     "1.64.0" "1.64" "1.63.0" "1.63" "1.62.0" "1.62" "1.61.0" "1.61" "1.60.0" "1.60"
     "1.59.0" "1.59" "1.58.0" "1.58" "1.57.0" "1.57" "1.56.0" "1.56" "1.55.0" "1.55"
     "1.54.0" "1.54" "1.53.0" "1.53" "1.52.0" "1.52" "1.51.0" "1.51"


### PR DESCRIPTION
Another routine updated; needed for the Boost 1.65.1 release which was released yesterday.  See https://gitlab.kitware.com/cmake/cmake/merge_requests/1241 (merged) and https://trello.com/c/KYijiouv/14-boost-1651, and also the homebrew PR https://github.com/Homebrew/homebrew-core/pull/17807 (merged).

Testing: Check builds remain green.  If you upgrade homebrew on the mac nodes, it will test it against 1.65.1.