### PR TITLE
cmake: Conditionally add log and log_setup to exported configuration

### DIFF
--- a/lib/ome/common/CMakeLists.txt
+++ b/lib/ome/common/CMakeLists.txt
@@ -132,6 +132,7 @@ if(OME_HAVE_BOOST_LOG)
   set(log_libraries
       Boost::log_setup
       Boost::log)
+  set(OME_COMMON_OPTIONAL_BOOST_COMPONENTS "log_setup log")
 endif()
 
 target_link_libraries(ome-common

--- a/lib/ome/common/OMECommonConfig.cmake.in
+++ b/lib/ome/common/OMECommonConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(OMECompat REQUIRED)
 find_dependency(Boost 1.46 REQUIRED
                 COMPONENTS date_time filesystem system iostreams
-                program_options regex)
+                program_options regex @OME_COMMON_OPTIONAL_BOOST_COMPONENTS@)
 find_dependency(XercesC 3.0.0 REQUIRED)
 find_dependency(XalanC 1.10 REQUIRED)
 

--- a/lib/ome/common/OMECommonConfig.cmake.in
+++ b/lib/ome/common/OMECommonConfig.cmake.in
@@ -1,12 +1,12 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(OMECompat REQUIRED)
-find_dependency(Boost 1.46 REQUIRED
+find_dependency(OMECompat)
+find_dependency(Boost 1.46
                 COMPONENTS date_time filesystem system iostreams
                 program_options regex @OME_COMMON_OPTIONAL_BOOST_COMPONENTS@)
-find_dependency(XercesC 3.0.0 REQUIRED)
-find_dependency(XalanC 1.10 REQUIRED)
+find_dependency(XercesC 3.0.0)
+find_dependency(XalanC 1.10)
 
 include("${CMAKE_CURRENT_LIST_DIR}/OMECommonInternal.cmake")
 


### PR DESCRIPTION
These were missing from the exported configuration.  Partly an oversight, and partly because they were conditionally used.  This adds them conditionally so should work in all cases.

Testing: Check all builds remain green.  Check OMECommonConfig.cmake and ensure that it contains:

```
find_dependency(Boost 1.46 REQUIRED
                COMPONENTS date_time filesystem system iostreams
                program_options regex log_setup log)
```

(in any build; CentOS7 platform builds will have it missing because Boost.Log is not available, but we don't have this in the CI builds yet.)