### PR TITLE
Require C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,10 @@ cmake_policy(VERSION 3.4.0)
 # For MSVC and FindThreads, respectively.
 enable_language(CXX C)
 
-# Enable C++11 support universally, with C++14 where available
+# Require C++14 support
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 endif()
 # Enable C99 support universally
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
See https://trello.com/c/dtwp7I14/11-c14-as-minimum-standard-version

We previously tried to use C++14, with a fallback to C++11 (in each component).  This is now adjusted to be C++14 only, with no fallback.  In practice, there are no changes because all the systems we test on have C++14-capable compilers.  The documentation has been updated to reflect the change.

Impact: very low.  Systems which support C++11 but not C++14 would be affected, but these are quite rare, since most C++11 compilers added some of the C++14 fixes even before C++11 was finalised.  Certainly for the subset of C++14 we need, there shouldn't be any difficulties.

Testing: Check all merge jobs on https://ci.openmicroscopy.org/view/Files/ are green.